### PR TITLE
Correction to the select function argument in ch04

### DIFF
--- a/ch04/app.py
+++ b/ch04/app.py
@@ -10,7 +10,7 @@ def get_orders_by_customer(cust_name, shipped=None, details=False):
                         dal.line_items.c.quantity,
                         dal.line_items.c.extended_cost])
         joins = joins.join(dal.line_items).join(dal.cookies)
-    cust_orders = select(columns)
+    cust_orders = select(*columns)
     cust_orders = cust_orders.select_from(joins).where(
         dal.users.c.username == cust_name)
     if shipped is not None:


### PR DESCRIPTION
 - As per the SQLAlchemy Core [documentation](https://docs.sqlalchemy.org/en/20/tutorial/data_select.html), To SELECT from individual columns using a Core approach, Column objects are accessed from the Table.c accessor and can be sent directly.
 - A list of columns is not accepted as an argument and throws the ArgumentError exception:

_E       sqlalchemy.exc.ArgumentError: Column expression, FROM clause, or other columns clause element expected, got   [Column('order_id', Integer(), table=<orders>), Column('username', String(length=15), table=<users>, nullable=False), Column('phone', String(length=20), table=<users>, nullable=False)].
   Did you mean to say select(Column('order_id', Integer(), table=<orders>), Column('username', String(length=15), table=<users>, nullable=False), Column('phone', String(length=20), table=<users>, nullable=False))?_


 - Instead of sending the list, pack the arguments using *